### PR TITLE
If verification of artifact failed - try to download it again

### DIFF
--- a/concreate/generator.py
+++ b/concreate/generator.py
@@ -68,7 +68,6 @@ class Generator(object):
         for artifact_dict in artifacts:
             artifact = tools.Artifact(artifact_dict)
             artifact.fetch()
-            artifact.verify()
 
     def override(self, overrides_path):
         logger.info("Using overrides file from '%s'." % overrides_path)

--- a/tests/test_unit_tools.py
+++ b/tests/test_unit_tools.py
@@ -15,14 +15,14 @@ res_bad_status.status_code = 500
 
 
 class TestTools(unittest.TestCase):
+    def setUp(self):
+        tools.cfg = {}
 
     @mock.patch('requests.get', return_value=res)
     def test_fetching_disable_ssl_verify(self, mock):
         tools.cfg['common'] = {}
         tools.cfg['common']['ssl_verify'] = "False"
-        artifact = tools.Artifact.__new__(tools.Artifact)
-        artifact.name = 'file'
-        artifact.artifact = 'dummy'
+        artifact = tools.Artifact({'name': 'file', 'artifact': 'dummy'})
         artifact.fetch()
         mock.assert_called_with('dummy', stream=True, verify=False)
         tools.Artifact.ssl_verify = True
@@ -31,21 +31,39 @@ class TestTools(unittest.TestCase):
 
     @mock.patch('requests.get', return_value=res_bad_status)
     def test_fetching_bad_status_code(self, mock):
-        artifact = tools.Artifact.__new__(tools.Artifact)
-        artifact.name = 'file'
-        artifact.artifact = 'dummy'
+        artifact = tools.Artifact({'name': 'file', 'artifact': 'dummy'})
         with self.assertRaises(ConcreateError):
             artifact.fetch()
 
     @mock.patch('requests.get', return_value=res)
-    def test_fetching_file_exists(self, mock):
+    def test_fetching_file_exists_but_used_as_is(self, mock):
+        """
+        It should not download the file, because we didn't
+        specify any hash algorithm, so integrity checking is
+        implicitly disabled here.
+        """
         with open('file', 'w') as f:
             pass
-        artifact = tools.Artifact.__new__(tools.Artifact)
-        artifact.name = 'file'
-        artifact.artifact = 'dummy'
+        artifact = tools.Artifact({'name': 'file', 'artifact': 'dummy'})
         artifact.fetch()
         mock.assert_not_called()
+        os.remove('file')
+
+    @mock.patch('requests.get', return_value=res)
+    def test_fetching_file_exists_fetched_again(self, mock):
+        """
+        It should download the file again, because available
+        file locally doesn't match checksum.
+        """
+        with open('file', 'w') as f:
+            pass
+        artifact = tools.Artifact({'name': 'file', 'artifact': 'dummy', 'md5': '123456'})
+        with self.assertRaises(ConcreateError):
+            # Checksum will fail, because the "downloaded" file
+            # will not have md5 equal to 123456. We need investigate
+            # mocking of requests get calls to do it properly
+            artifact.fetch()
+        mock.assert_called_with('dummy', stream=True, verify=True)
         os.remove('file')
 
     def test_artifact_verify_disabled_integrity_check(self):


### PR DESCRIPTION
When a file exists on disk and the checksum is not correct
we should try to download that file again and fail
if the checksum after download is still not correct.

Fixes #9