### PR TITLE
Better processing of important labels

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,2 +1,3 @@
 linters:
-  flake8: {  }
+  flake8:
+    max-line-length: 100

--- a/concreate/descriptor.py
+++ b/concreate/descriptor.py
@@ -44,6 +44,12 @@ class Descriptor(object):
     def items(self):
         return self.descriptor.items()
 
+    def label(self, key):
+        for l in self.descriptor['labels']:
+            if l['name'] == key:
+                return l
+        return None
+
     def process(self):
         """ Prepare descriptor to be used by generating defaults """
         if 'artifacts' in self.descriptor:
@@ -105,9 +111,27 @@ class Descriptor(object):
         """ Generate labels from concreate keys """
         if "labels" not in self.descriptor:
             self.descriptor['labels'] = []
-        if "description" in self.descriptor:
-            self.descriptor['labels'].append({'name': 'description',
-                                              'value': self.descriptor['description']})
+
+        # The description key available in image descriptor's
+        # root is added as labels to the image
+        key = 'description'
+
+        # If we define the label in the image descriptor
+        # we should *not* override it with value from
+        # the root's key
+        if key in self.descriptor and not self.label(key):
+            value = self.descriptor[key]
+            self.descriptor['labels'].append({'name': key, 'value': value})
+
+        # Last - if there is no 'summary' label added to image descriptor
+        # we should use the value of the 'description' key and create
+        # a 'summary' label with it's content. If there is even that
+        # key missing - we should not add anything.
+        description = self.label('description')
+
+        if not self.label('summary') and description:
+            self.descriptor['labels'].append(
+                {'name': 'summary', 'value': description['value']})
 
 
 def merge_dictionaries(dict1, dict2):

--- a/concreate/schema/image_schema.yaml
+++ b/concreate/schema/image_schema.yaml
@@ -39,7 +39,6 @@ map:
           value: {type: int, required: True}
           expose: {type: bool}
           description: {type: str}
-  maintainer: {type: str}
   workdir: {type: str}
   artifacts:
     seq:

--- a/concreate/schema/overrides_schema.yaml
+++ b/concreate/schema/overrides_schema.yaml
@@ -38,7 +38,6 @@ map:
           value: {type: int}
           expose: {type: bool}
           description: {type: str}
-  maintainer: {type: str}
   workdir: {type: str}
   artifacts:
     seq:

--- a/tests/test_unit_descriptor.py
+++ b/tests/test_unit_descriptor.py
@@ -1,4 +1,7 @@
+import os
+import tempfile
 import unittest
+import yaml
 
 from concreate import descriptor
 from concreate.errors import ConcreateError
@@ -78,3 +81,57 @@ class TestMergingLists(unittest.TestCase):
 
         self.assertEqual(expected,
                          descriptor.merge_lists(list1, list2))
+
+
+class TestLabels(unittest.TestCase):
+
+    def setUp(self):
+        _, self.descriptor = tempfile.mkstemp()
+
+    def tearDown(self):
+        os.remove(self.descriptor)
+
+    def prepare_descriptor(self, data={}):
+        image = {'name': 'image/name', 'version': 1.0,
+                 'from': 'from/image', 'schema_version': 1}
+        image.update(data)
+
+        with open(self.descriptor, 'w') as outfile:
+            yaml.dump(image, outfile, default_flow_style=False)
+
+    def test_no_labels_should_be_added(self):
+        self.prepare_descriptor()
+
+        img_descriptor = descriptor.Descriptor(self.descriptor, 'image')
+        img_descriptor._process_labels()
+
+        self.assertIsNone(img_descriptor.label('description'))
+        self.assertIsNone(img_descriptor.label('summary'))
+        self.assertIsNone(img_descriptor.label('maintainer'))
+
+    def test_description_label_should_be_added(self):
+        self.prepare_descriptor({'description': 'This is image description'})
+
+        img_descriptor = descriptor.Descriptor(self.descriptor, 'image')
+        img_descriptor._process_labels()
+
+        self.assertIsNone(img_descriptor.label('maintainer'))
+        self.assertEqual(img_descriptor.label('description').get(
+            'value'), 'This is image description')
+        # In this case the 'summary' label should be also set
+        self.assertEqual(img_descriptor.label('summary').get(
+            'value'), 'This is image description')
+
+    def test_description_and_summary_labels_should_not_be_overriden(self):
+        self.prepare_descriptor({'description': 'This is image description', 'labels': [
+                                {'name': 'summary', 'value': 'summary value'},
+                                {'name': 'description', 'value': 'description value'}]})
+
+        img_descriptor = descriptor.Descriptor(self.descriptor, 'image')
+        img_descriptor._process_labels()
+
+        self.assertIsNone(img_descriptor.label('maintainer'))
+        self.assertEqual(img_descriptor.label(
+            'description').get('value'), 'description value')
+        self.assertEqual(img_descriptor.label(
+            'summary').get('value'), 'summary value')


### PR DESCRIPTION
Labels description and summary are set up correctly based on the description key in the image descriptor.
    
See code for more information.
    
Fixes #12