### PR TITLE
Revisit modules section in image descriptor

### DIFF
--- a/concreate/generator.py
+++ b/concreate/generator.py
@@ -42,11 +42,11 @@ class Generator(object):
 
         # If descriptor doesn't requires any module we can start merging descriptors
         # and fetching artifacts. There ibs nothing left to do except for this
-        if 'modules' not in descriptor:
+        if 'modules' not in descriptor or 'install' not in descriptor['modules']:
             self.effective_descriptor.merge(descriptor)
             return
 
-        for module in descriptor['modules']:
+        for module in descriptor['modules']['install']:
             version = None
             if 'version' in module:
                 version = module['version']

--- a/concreate/schema/image_schema.yaml
+++ b/concreate/schema/image_schema.yaml
@@ -62,25 +62,27 @@ map:
     seq:
       - {type: str}
   modules:
-    seq:
-      - map:
-          name: {type: str, required: True}
-          version: {type: str}
-  dependencies:
-    seq:
-      - type: map
-        mapping:
-          name: {type: str}
-          git: 
-              type: map
-              mapping:
-                  url: {type: str, required: True}
-                  ref: {type: str}
-          file: {type: str, required: False}
-          url: {type: str, required: False}
-          md5: {type: str}
-          sha1: {type: str}
-          sha256: {type: str}
-          description: {type: str}
-        assert: "val['git'] is not None or val['file'] is not None or val['url] is not None"
+    map:
+      repositories:
+        seq:
+          - type: map
+            mapping:
+              name: {type: str}
+              git:
+                  type: map
+                  mapping:
+                      url: {type: str, required: True}
+                      ref: {type: str}
+              file: {type: str, required: False}
+              url: {type: str, required: False}
+              md5: {type: str}
+              sha1: {type: str}
+              sha256: {type: str}
+              description: {type: str}
+            assert: "val['git'] is not None or val['file'] is not None or val['url] is not None"
+      install:
+        seq:
+        - map:
+            name: {type: str, required: True}
+            version: {type: str}
 

--- a/concreate/schema/overrides_schema.yaml
+++ b/concreate/schema/overrides_schema.yaml
@@ -61,24 +61,26 @@ map:
     seq:
       - {type: str}
   modules:
-    seq:
-      - map:
-          name: {type: str}
-          version: {type: str}
-  dependencies:
-    seq:
-      - type: map
-        mapping:
-          name: {type: str}
-          git: 
-              type: map
-              mapping:
-                  url: {type: str, required: True}
-                  ref: {type: str}
-          file: {type: str, required: False}
-          url: {type: str, required: False}
-          md5: {type: str}
-          sha1: {type: str}
-          sha256: {type: str}
-          description: {type: str}
-        assert: "val['git'] is not None or val['file'] is not None or val['url] is not None"
+    map:
+      repositories:
+        seq:
+          - type: map
+            mapping:
+              name: {type: str}
+              git:
+                  type: map
+                  mapping:
+                      url: {type: str, required: True}
+                      ref: {type: str}
+              file: {type: str, required: False}
+              url: {type: str, required: False}
+              md5: {type: str}
+              sha1: {type: str}
+              sha256: {type: str}
+              description: {type: str}
+            assert: "val['git'] is not None or val['file'] is not None or val['url] is not None"
+      install:
+        seq:
+        - map:
+            name: {type: str, required: True}
+            version: {type: str}


### PR DESCRIPTION
The 'modules' section was reworked. A new 'repositories' section was
added (which replaced the top level 'dependencies') and another
'install' was added to be able to list all modules that need to be
"installed/processed" to generate the image.
    
Fixes #29.

Based on #38.