### PR TITLE
OSBS builder will not die if there are no artifacts for rhpkg new-sources command

### DIFF
--- a/concreate/builders/osbs.py
+++ b/concreate/builders/osbs.py
@@ -72,10 +72,17 @@ class OSBSBuilder(Builder):
 
     def update_lookaside_cache(self):
         logger.info("Updating lookaside cache...")
+        if not self.artifacts:
+            return
         cmd = ["rhpkg", "new-sources"] + self.artifacts
         logger.debug("Executing '%s'" % cmd)
         with Chdir(self.dist_git_dir):
-            subprocess.check_output(cmd)
+            try:
+                subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as ex:
+                logger.error("Cannot run '%s', ouput: '%s'" % (cmd, ex.output))
+                raise ConcreateError("Cannot update sources.")
+
         logger.info("Update finished.")
 
     def build(self, build_args):

--- a/concreate/version.py
+++ b/concreate/version.py
@@ -1,2 +1,2 @@
-version = "1.3.0"
+version = "1.3.1"
 schema_version = 1

--- a/rpm/python-concreate.spec
+++ b/rpm/python-concreate.spec
@@ -7,7 +7,7 @@
 %global modname concreate
 
 Name:           python-concreate
-Version:        1.3.0
+Version:        1.3.1
 Release:        1%{?dist}
 Summary:        Container image creation tool
 License:        MIT


### PR DESCRIPTION
fixes #140 