### PR TITLE
test documentation overhaul

### DIFF
--- a/docs/test.rst
+++ b/docs/test.rst
@@ -1,9 +1,11 @@
-Testing image
-=============
+Testing images
+==============
 
-Concreate is able to run `behave <https://pythonhosted.org/behave/>`_ based test for the image. We suggest to read behave documentation before reading this chapter.
+Concreate is able to run `behave <https://pythonhosted.org/behave/>`_ based
+test for images. We suggest you read the Behave documentation before reading
+this chapter.
 
-Image can be tested by running:
+An image can be tested by running:
 
 .. code:: bash
 	  
@@ -11,37 +13,46 @@ Image can be tested by running:
 
 **Test options**
 
-* ``--test-wip`` -- run only tests tagged with ``@wip`` tag.
+* ``--test-wip`` -- only run tests tagged with the ``@wip`` tag.
 * ``--test-steps-url`` -- a git repository url containing `steps <https://pythonhosted.org/behave/tutorial.html#python-step-implementations>`_ for tests.
-* ``--tag`` -- an image tag used to determine image which will be tests. It can be specified multiple times but only the first occurence is honored.
+* ``--tag`` --  only run tests tagged with the supplied tag. Only the
+                first occurence of this argument is honoured.
 
 
 About Tests
 -----------
-Behave tests are separate to two parts steps and features. You can place tests in ``tests`` directory next
-to the image descriptor, module descriptor or in a root of a git repository which contains the modules.
 
-The tests directory is structured in following way:
+Behave tests are defined in two separate parts: steps and features.
+
+You can place the files defining tests in a ``tests`` directory next to the
+image descriptor, module descriptor or in a root of a git repository which
+contains the modules.
+
+The tests directory is structured as follows:
 
 .. code::
    
           tests/features
-          tests/features/amq.features
+          tests/features/amq.feature
           tests/steps
           tests/steps/custom_steps.py
 
 
-The ``tests/features`` directory is the place where you can drop your custom developed `behave features. <https://pythonhosted.org/behave/gherkin.html>`_
+The ``tests/features`` directory is the place where you can drop your `behave features. <https://pythonhosted.org/behave/gherkin.html>`_
 
 The ``tests/steps`` directory is optional and contains custom `steps <https://pythonhosted.org/behave/tutorial.html#python-step-implementations>`_ for specific image/module.
 
 We strongly recommend that a test is written for every feature that is added to the image.
-For the list of steps that are available for use in tests, see the `steps repository <https://github.com/jboss-openshift/concreate-test-steps>`_.
-Where necessary we encourage people to add or extend the steps.
+
+Concreate comes with a list of build-in steps that are available for use in
+tests. See the `steps repository <https://github.com/jboss-openshift/concreate-test-steps>`_.
+
+Where necessary we encourage people to add or extend these steps.
 
 **Tags**
 
-Concreate is selecting which test to run via tags mechanism. There are two way the tags are used:
+Concreate selects which tests to run via the *tags* mechanism. There are two
+way that tags are used:
 
 1. `Product tags`
    

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -53,18 +53,25 @@ Where necessary we encourage people to add or extend these steps.
 
 **Tags**
 
-Concreate selects which tests to run via the *tags* mechanism. There are two
-way that tags are used:
+Concreate selects which tests to run via the *tags* mechanism. Here are three
+ways that tags could be used for managing tests across a set of related images:
 
 1. `Product tags`
    
-   These tags are based on product names. When a product image is tested, concreate uses tag containing image name and its product family name.
-   **Example**: If you are testing ``jboss-eap-7/eap7`` image, test will be invoked with tag ``@jboss-eap-7`` and ``@jboss-eap-7/eap7``.
+   Tags based on product names. When a product image is tested, concreate uses
+   tags containing the image name and its product family name.  **Example**: If
+   you are testing ``jboss-eap-7/eap7`` image, test will be invoked with tag
+   ``@jboss-eap-7`` and ``@jboss-eap-7/eap7``.
 
 2. `Wip tags`
    
-   This is very special behavior used mainly in development. It servers purpose you want to limit test to be run to a subset you are working on. To achieve this you should mark your test scenario with ``@wip`` tag and run ``concreate test --test-wip``
+   This is very special behavior used mainly in development. Its purpose is to
+   to limit the tests to be run to a subset you are working on. To achieve this
+   you should mark your in-development test scenarios with the ``@wip`` tag and
+   run ``concreate test --test-wip``.
 
 3. `Custom tags`
 
-   You can test an particular image using via ``--tag`` option. To run test for image 'foo' you can run ``concreate test --tag foo``
+   You can restrict tests to those for a particular image using the ``--tag``
+   option. **Example**: To run only the tests for image 'foo' you can run
+   ``concreate test --tag foo``

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -15,7 +15,7 @@ An image can be tested by running:
 
 * ``--test-wip`` -- only run tests tagged with the ``@wip`` tag.
 * ``--test-steps-url`` -- a git repository url containing `steps <https://pythonhosted.org/behave/tutorial.html#python-step-implementations>`_ for tests.
-* ``--tag @sometag`` --  only run tests tagged with e.g. ``@sometag``. Only the first occurrence of this argument is honoured.
+* ``--tag altname`` --  Overrides the name of the Image used for testing to ``altname``. Only the first occurrence of this argument is honoured.
 
 
 About Tests
@@ -59,27 +59,31 @@ of related images:
 
 1. `Product tags`
    
-   Tags based on product names. When a product image is tested, concreate uses
-   tags containing the image name and its product family name.  **Example**: If
-   you are testing ``jboss-eap-7/eap7`` image, test will be invoked with tag
-   ``@jboss-eap-7`` and ``@jboss-eap-7/eap7``.
+   Tags based on image names. Concreate derives two test tag names from the
+   name of the Image being tested. The whole image name is converted into one
+   tag, and everything before the first '/' character is converted into
+   another.
+   **Example**: If you are testing the ``jboss-eap-7/eap7`` image,
+   tests will be invoked with tags ``@jboss-eap-7`` and ``@jboss-eap-7/eap7``.
+
+   If ``--tag`` is specified, then the argument is used in place of the Image
+   name for the process above.
+   **Example** If you provided ``--tag foo/bar``, then the tags used would be
+   ``@foo`` and ``@foo/bar``.
 
 2. `Wip tags`
    
    This is very special behavior used mainly in development. Its purpose is to
    to limit the tests to be run to a subset you are working on. To achieve this
    you should mark your in-development test scenarios with the ``@wip`` tag and
-   run ``concreate test --test-wip``.
+   run ``concreate test --test-wip``. All other scenarios not tagged ``@wip``
+   will be ignored.
 
-3. `Custom tags`
+3. `The @ci tag`
 
-   You can restrict tests to those for a particular image using the ``--tag``
-   option. **Example**: To run only the tests for image 'foo' you can run
-   ``concreate test --tag foo``
+   If ``concreate`` is not running as a user called ``jenkins``, the tag ``@ci``
+   is added to the list of ignored tags, meaning any tests tagged ``@ci`` are
+   ignored and not executed.
 
-4. `Environment tags`
-
-   You may wish to define some scenarios that are only executed when running
-   tests in some environment. **Example** you may write some tests that only
-   make sense to execute as part of a Continuous Integration system. You could
-   mark such tests with ``@ci``.
+   The purpose of this behavior is to ease specifying tests that are only
+   executed when run within Jenkins CI.

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -2,7 +2,7 @@ Testing images
 ==============
 
 Concreate is able to run `behave <https://pythonhosted.org/behave/>`_ based
-test for images. We suggest you read the Behave documentation before reading
+tests for images. We suggest you read the Behave documentation before reading
 this chapter.
 
 An image can be tested by running:
@@ -15,7 +15,7 @@ An image can be tested by running:
 
 * ``--test-wip`` -- only run tests tagged with the ``@wip`` tag.
 * ``--test-steps-url`` -- a git repository url containing `steps <https://pythonhosted.org/behave/tutorial.html#python-step-implementations>`_ for tests.
-* ``--tag`` --  only run tests tagged with the supplied tag. Only the first occurence of this argument is honoured.
+* ``--tag @sometag`` --  only run tests tagged with e.g. ``@sometag``. Only the first occurrence of this argument is honoured.
 
 
 About Tests
@@ -37,9 +37,12 @@ The tests directory is structured as follows:
           tests/steps/custom_steps.py
 
 
-The ``tests/features`` directory is the place where you can drop your `behave features. <https://pythonhosted.org/behave/gherkin.html>`_
+The ``tests/features`` directory is the place where you can drop your `behave
+features. <https://pythonhosted.org/behave/gherkin.html>`_
 
-The ``tests/steps`` directory is optional and contains custom `steps <https://pythonhosted.org/behave/tutorial.html#python-step-implementations>`_ for specific image/module.
+The ``tests/steps`` directory is optional and contains custom `steps
+<https://pythonhosted.org/behave/tutorial.html#python-step-implementations>`_
+for the specific image/module.
 
 We strongly recommend that a test is written for every feature that is added to the image.
 

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -53,8 +53,9 @@ Where necessary we encourage people to add or extend these steps.
 
 **Tags**
 
-Concreate selects which tests to run via the *tags* mechanism. Here are three
-ways that tags could be used for managing tests across a set of related images:
+Concreate selects which tests to run via the *tags* mechanism. Here are several
+examples of ways ways that tags could be used for managing tests across a set
+of related images:
 
 1. `Product tags`
    
@@ -75,3 +76,10 @@ ways that tags could be used for managing tests across a set of related images:
    You can restrict tests to those for a particular image using the ``--tag``
    option. **Example**: To run only the tests for image 'foo' you can run
    ``concreate test --tag foo``
+
+4. `Environment tags`
+
+   You may wish to define some scenarios that are only executed when running
+   tests in some environment. **Example** you may write some tests that only
+   make sense to execute as part of a Continuous Integration system. You could
+   mark such tests with ``@ci``.

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -15,8 +15,7 @@ An image can be tested by running:
 
 * ``--test-wip`` -- only run tests tagged with the ``@wip`` tag.
 * ``--test-steps-url`` -- a git repository url containing `steps <https://pythonhosted.org/behave/tutorial.html#python-step-implementations>`_ for tests.
-* ``--tag`` --  only run tests tagged with the supplied tag. Only the
-                first occurence of this argument is honoured.
+* ``--tag`` --  only run tests tagged with the supplied tag. Only the first occurence of this argument is honoured.
 
 
 About Tests


### PR DESCRIPTION
Some changes to the test documentation page based in part on some older documentation from before we used concreate.